### PR TITLE
Fix création évent disctinction org/client

### DIFF
--- a/src/repositories/event.repository.js
+++ b/src/repositories/event.repository.js
@@ -6,7 +6,7 @@ import User from "../models/User.js";
 import Client from "../models/Client.js";
 import Organisation from "../models/Organisation.js";
 import geocodingService from "../services/geocoding.service.js";
-import { CertificationRequest, Role } from "../models/index.js";
+import { CertificationRequest } from "../models/index.js";
 
 class EventRepository {
   async create(eventData) {
@@ -25,16 +25,9 @@ class EventRepository {
       eventData.LocationID = location[0].dataValues.ID;
       const newEvent = await Event.create(eventData);
 
-      if (
-        (await User.findByPk(newEvent.dataValues.UserID).RoleID) ===
-        (await Role.findOne({
-          where: {
-            Name: "Client",
-          },
-        }).ID)
-      ) {
-        console.log("Creating certification request");
-
+      // Règle métier: seule un utilisateur rôle Client (RoleID = 1) génère une demande de certification pour son événement.
+      const user = await User.findByPk(newEvent.dataValues.UserID);
+      if (user && user.RoleID === 1) {
         await CertificationRequest.create({
           TargetType: "event",
           TargetID: newEvent.dataValues.ID,


### PR DESCRIPTION
Modification du filtre pour la certification d'événement avec la distinction entre un organisateur et un client ( roleID ==1)